### PR TITLE
Remove "TODO" print when parsing non-ascii characters

### DIFF
--- a/pylnk3.py
+++ b/pylnk3.py
@@ -991,7 +991,7 @@ class LinkInfo(object):
             self.offs_network_volume_table = read_int(lnk)
             self.offs_base_name = read_int(lnk)
             if self.header_size >= _LINK_INFO_HEADER_OPTIONAL:
-                print("TODO: read the unicode stuff")  # TODO: read the unicode stuff
+                pass # TODO: read the unicode stuff
             self._parse_path_elements(lnk)
         else:
             self.size = None


### PR DESCRIPTION
Hi,

we are using this library on [NetExec](https://github.com/Pennyw0rth/NetExec). Currently i am reviewing a Pull Requests that parses Windows links with your tool and when parsing links that contain non-ascii characters a TODO is printed to stdout:

![image](https://github.com/user-attachments/assets/b618bc9a-944b-47d0-b003-e3eb485b6be8)

This PR removes the print, but keeps the comment so you can still read up "unicode stuff" if you would like to :D

A new release to pypi would be highly appreciated, so that we can update our version!