### PR TITLE
Fix encoding Unicode path segments with wrong segment type

### DIFF
--- a/pylnk3.py
+++ b/pylnk3.py
@@ -131,6 +131,7 @@ _ROOT_LOCATION_GUIDS = dict((v, k) for k, v in _ROOT_LOCATIONS.items())
 
 TYPE_FOLDER = 'FOLDER'
 TYPE_FILE = 'FILE'
+TYPE_UNICODE_SUFFIX = ' (UNICODE)'
 _ENTRY_TYPES = {
     0x00: 'KNOWN_FOLDER',
     0x31: 'FOLDER',
@@ -523,7 +524,7 @@ class PathSegmentEntry(object):
 
         buf = BytesIO(bytes)
         self.type = _ENTRY_TYPES.get(read_short(buf), 'UNKNOWN')
-        short_name_is_unicode = self.type.endswith('(UNICODE)')
+        short_name_is_unicode = self.type.endswith(TYPE_UNICODE_SUFFIX)
 
         if self.type == 'ROOT_KNOWN_FOLDER':
             self.full_name = '::' + guid_from_bytes(buf.read(16))
@@ -656,15 +657,21 @@ class PathSegmentEntry(object):
             write_short(0x14, out)  # unknown
             return out.getvalue()
 
+        already_has_unicode_type = entry_type.endswith(TYPE_UNICODE_SUFFIX)
         short_name_len = len(self.short_name) + 1
         try:
             self.short_name.encode("ascii")
             short_name_is_unicode = False
             short_name_len += short_name_len % 2  # padding
+            if already_has_unicode_type:
+                entry_type = entry_type[:-len(TYPE_UNICODE_SUFFIX)]
+                self.type = entry_type
         except (UnicodeEncodeError, UnicodeDecodeError):
             short_name_is_unicode = True
             short_name_len = short_name_len * 2
-            self.type += " (UNICODE)"
+            if not already_has_unicode_type:
+                entry_type += TYPE_UNICODE_SUFFIX
+                self.type = entry_type
         write_short(_ENTRY_TYPE_IDS[entry_type], out)
         write_int(self.file_size, out)
         write_dos_datetime(self.modified, out)


### PR DESCRIPTION
Currently, creating a new link with non-ASCII path segments will not round trip:
```py
import pylnk3
from io import BytesIO

lnk = pylnk3.for_file(r'C:\Ascii\AlsoAscii\NonAscii£\FinalAscii')
print(lnk.path) # C:\Ascii\AlsoAscii\NonAscii£\FinalAscii

buf = BytesIO()
lnk.write(buf)
lnk = pylnk3.parse(buf)
print(lnk.path) # C:\Ascii\AlsoAscii\FinalAscii
```

This is because, although `PathSegmentEntry.bytes` will update `self.type` and use UTF-16 if it detects that the segment is non-ASCII, it doesn't actually use the updated type in the output data. This means you can get a file that was encoded with UTF-16 but has the segment type set to `FOLDER` or `FILE` instead of `FOLDER (UNICODE)` or `FILE (UNICODE)`. Attempting to parse the segment will therefore use the default code page to read UTF-16 data and fail silently.

Additionally, the way `self.type` is treated during encoding assumes that the segment is not already `FOLDER (UNICODE)` or `FILE (UNICODE)`. Encoding such a segment could result in the opposite problem, where text is encoded with the default code page but the type doesn't have the Unicode flag set, or even set `self.type` to something like `FOLDER (UNICODE) (UNICODE)`.

This fix ensures that the `(UNICODE)` suffix is added or removed correctly based on the selected text encoding, and that the updated segment type is written to the file.